### PR TITLE
Improved commandModel(String) in CommandExecutor

### DIFF
--- a/src/main/kotlin/de/tammo/kommand/executor/CommandExecutor.kt
+++ b/src/main/kotlin/de/tammo/kommand/executor/CommandExecutor.kt
@@ -56,7 +56,7 @@ object CommandExecutor {
      */
     fun commandModel(label: String) = commands.find {
         it.label.toLowerCase() == label.toLowerCase() ||
-                it.aliases.map { alias -> alias.toLowerCase() }.contains(label.toLowerCase())
+                it.aliases.find { alias -> alias.toLowerCase() == label.toLowerCase() }
     }
 
 }


### PR DESCRIPTION
Switched to find instead of map & contains